### PR TITLE
import_caddy|apache|nginx_waf.py fixes

### DIFF
--- a/import_apache_waf.py
+++ b/import_apache_waf.py
@@ -6,7 +6,6 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 
 WAF_DIR = "waf_patterns/apache"
 APACHE_WAF_DIR = "/etc/modsecurity.d/"
-
 APACHE_CONF = "/etc/apache2/apache2.conf"
 INCLUDE_STATEMENT = "IncludeOptional /etc/modsecurity.d/*.conf"
 
@@ -18,13 +17,8 @@ def copy_waf_files():
     list_of_files = os.listdir(WAF_DIR)
     workaround = "{"
     for conf_file in list_of_files:
-        # print(conf_file)
         if conf_file.endswith('.conf'):
             subprocess.run(["cp", f"{WAF_DIR}/{conf_file}", APACHE_WAF_DIR], check=True)
-            # print("Match")
-    workaround = workaround[:-1] # removes the last comma
-    workaround += "}"
-    print(workaround)
 
     
 
@@ -47,7 +41,6 @@ def reload_apache():
     subprocess.run(["systemctl", "reload", "apache2"], check=True)
 
 if __name__ == "__main__":
-
     copy_waf_files()
     update_apache_conf()
     reload_apache()

--- a/import_apache_waf.py
+++ b/import_apache_waf.py
@@ -15,7 +15,6 @@ def copy_waf_files():
     logging.info("Copying Apache WAF patterns...")
     os.makedirs(APACHE_WAF_DIR, exist_ok=True)
     list_of_files = os.listdir(WAF_DIR)
-    workaround = "{"
     for conf_file in list_of_files:
         if conf_file.endswith('.conf'):
             subprocess.run(["cp", f"{WAF_DIR}/{conf_file}", APACHE_WAF_DIR], check=True)

--- a/import_apache_waf.py
+++ b/import_apache_waf.py
@@ -5,8 +5,7 @@ import logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 WAF_DIR = "waf_patterns/apache"
-# APACHE_WAF_DIR = "/etc/modsecurity.d/" # remember to change this back to this
-APACHE_WAF_DIR = "testing/" # remember to change this back to this
+APACHE_WAF_DIR = "/etc/modsecurity.d/"
 
 APACHE_CONF = "/etc/apache2/apache2.conf"
 INCLUDE_STATEMENT = "IncludeOptional /etc/modsecurity.d/*.conf"

--- a/import_apache_waf.py
+++ b/import_apache_waf.py
@@ -5,14 +5,29 @@ import logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 WAF_DIR = "waf_patterns/apache"
-APACHE_WAF_DIR = "/etc/modsecurity.d/"
+# APACHE_WAF_DIR = "/etc/modsecurity.d/" # remember to change this back to this
+APACHE_WAF_DIR = "testing/" # remember to change this back to this
+
 APACHE_CONF = "/etc/apache2/apache2.conf"
 INCLUDE_STATEMENT = "IncludeOptional /etc/modsecurity.d/*.conf"
+
+
 
 def copy_waf_files():
     logging.info("Copying Apache WAF patterns...")
     os.makedirs(APACHE_WAF_DIR, exist_ok=True)
-    subprocess.run(["cp", "-R", f"{WAF_DIR}/*", APACHE_WAF_DIR], check=True)
+    list_of_files = os.listdir(WAF_DIR)
+    workaround = "{"
+    for conf_file in list_of_files:
+        # print(conf_file)
+        if conf_file.endswith('.conf'):
+            subprocess.run(["cp", f"{WAF_DIR}/{conf_file}", APACHE_WAF_DIR], check=True)
+            # print("Match")
+    workaround = workaround[:-1] # removes the last comma
+    workaround += "}"
+    print(workaround)
+
+    
 
 def update_apache_conf():
     logging.info("Ensuring WAF patterns are included in apache2.conf...")
@@ -33,6 +48,7 @@ def reload_apache():
     subprocess.run(["systemctl", "reload", "apache2"], check=True)
 
 if __name__ == "__main__":
+
     copy_waf_files()
     update_apache_conf()
     reload_apache()

--- a/import_caddy_waf.py
+++ b/import_caddy_waf.py
@@ -12,7 +12,10 @@ INCLUDE_STATEMENT = "import waf/*.conf"
 def copy_waf_files():
     logging.info("Copying Caddy WAF patterns...")
     os.makedirs(CADDY_WAF_DIR, exist_ok=True)
-    subprocess.run(["cp", "-R", f"{WAF_DIR}/*", CADDY_WAF_DIR], check=True)
+    list_of_files = os.listdir(WAF_DIR)
+    for conf_file in list_of_files:
+        if conf_file.endswith('.conf'):
+            subprocess.run(["cp", f"{WAF_DIR}/{conf_file}", CADDY_WAF_DIR], check=True)
 
 def update_caddyfile():
     logging.info("Ensuring WAF patterns are imported in Caddyfile...")

--- a/import_nginx_waf.py
+++ b/import_nginx_waf.py
@@ -12,7 +12,10 @@ INCLUDE_STATEMENT = "include /etc/nginx/waf/*.conf;"
 def copy_waf_files():
     logging.info("Copying Nginx WAF patterns...")
     os.makedirs(NGINX_WAF_DIR, exist_ok=True)
-    subprocess.run(["cp", "-R", f"{WAF_DIR}/*", NGINX_WAF_DIR], check=True)
+    list_of_files = os.listdir(WAF_DIR)
+    for conf_file in list_of_files:
+        if conf_file.endswith('.conf'):
+            subprocess.run(["cp", f"{WAF_DIR}/{conf_file}", NGINX_WAF_DIR], check=True)
 
 def update_nginx_conf():
     logging.info("Ensuring WAF patterns are included in nginx.conf...")


### PR DESCRIPTION
Heya! This is referencing [this](https://github.com/fabriziosalmi/patterns/issues/1#issue-2754046068) issue - currently I have only implemented an Apache fix because I wanted to check you are okay with the solution first :) 

It seems the `*` wouldn't be passed to the shell, and so I initially tried to get this to work with using a setup like `/dir/to/files/{a,b,c,d}` but I ran into `cp`'s character limit (did not know this was a thing lol) - I am not a fan of copying the files over individually - it is probably possibly to copy the dir over then expand it but I didn't want to go toooo crazy.

Will probs do these changes for the other files affected as well and commit it, no pressure to use a different solution/do lemme know if you want me to make any changes!