### PR TITLE
docs: correct Python requirement to 3.9+ (matches CI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Then follow the [Nginx](https://fabriziosalmi.github.io/patterns/nginx),
 
 ### Option 2 &mdash; build from source
 
-Requires **Python 3.11+**, `pip`, and `git`.
+Requires **Python 3.9+**, `pip`, and `git`.
 
 ```bash
 git clone https://github.com/fabriziosalmi/patterns.git


### PR DESCRIPTION
## What
The README stated **"Requires Python 3.11+"**, but:
- `test_nginx.yml` runs the converters/validation on **Python 3.9** (and passes),
- the converters use no 3.10+ syntax (the `match` occurrences are a regex variable, not the statement).

So 3.9 is actually supported. Relax the README claim to **Python 3.9+** so the docs match reality and what CI validates.

> Alternative if 3.11 is intended as a hard floor: bump `test_nginx.yml` to 3.11 instead. Went with the accurate, less-restrictive fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)