### PR TITLE
seo(docs): genera la sitemap.xml (VitePress)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
     titleTemplate: ':title — Patterns',
     description: 'Automated OWASP CRS and bad-bot rules for Nginx, Apache, Traefik, and HAProxy.',
     base: '/patterns/',
+    // The hostname carries the base path on purpose: VitePress joins it with each
+    // page's route, so without it every URL in the sitemap would point at a 404.
+    sitemap: { hostname: 'https://fabriziosalmi.github.io/patterns/' },
     cleanUrls: true,
     lastUpdated: true,
 


### PR DESCRIPTION
VitePress sa generare la sitemap da solo: serve solo `sitemap.hostname`.

**L'hostname deve portarsi dietro il base path.** VitePress lo unisce alla rotta di ogni pagina, quindi senza di esso ogni URL della sitemap punterebbe a un 404 ([docs](https://vitepress.dev/guide/sitemap-generation#options)).

**Verificato costruendo davvero il sito**, non solo leggendo la config: **8 URL** generati, tutti con il base corretto. Primo URL della sitemap: `https://fabriziosalmi.github.io/patterns/apache`

**Perché conta qui:** la home linka **8** pagine, il sito ne ha **8**. La differenza Google la trova solo per caso.

Tre righe in `docs/.vitepress/config.ts`, nessun file nuovo, nessuna dipendenza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
