### PR TITLE
fix(nginx): measure the parameter limit in bytes, at the value nginx accepts

### DIFF
--- a/.github/workflows/test_nginx.yml
+++ b/.github/workflows/test_nginx.yml
@@ -44,6 +44,9 @@ jobs:
     # that a parameter may not exceed 4096 characters, or that `add_header` is
     # not allowed inside an `if` in server context. All three shipped for months
     # with this job green (#21, #22, #23), so it now runs nginx itself.
+    - name: Pin the parameter limit to what nginx accepts
+      run: python3 tests/test_parameter_limit.py
+
     - name: Validate the committed configuration
       run: python3 tests/validate_nginx.py
 

--- a/json2nginx.py
+++ b/json2nginx.py
@@ -167,10 +167,29 @@ def is_case_insensitive(pattern: str, transformations: List[str]) -> bool:
     return any(t in ("lowercase", "cmdline", "normalizepath") for t in transformations)
 
 
-# nginx refuses a configuration parameter longer than this. Verified against
-# nginx 1.31.5: a quoted map key of 4096 characters loads, 4097 does not
-# ("too long parameter, probably missing terminating \" character").
-NGINX_MAX_PARAMETER = 4096
+# nginx refuses a configuration parameter longer than this, in bytes.
+#
+# One over-long parameter is not one lost rule: nginx refuses the file, so the
+# whole rule set stops loading. That failure shipped once already (#22), which
+# is why the limit is measured rather than assumed.
+#
+# The previous value, 4096, was one above the boundary, and the comparison
+# against it emitted a key nginx refuses. Binary-searched with `nginx -t`, on
+# nginx 1.31.5 and on the nginx the Ubuntu runners install: 4095 bytes loads,
+# 4096 does not ("too long parameter, probably missing terminating \"
+# character"). The limit is on the parameter, not the line: a 4095-byte key
+# loads on a line of 4508 characters.
+#
+# tests/test_parameter_limit.py binary-searches the local nginx for the same
+# boundary and fails if this constant is above it, so a stricter build is caught
+# rather than assumed away with a margin.
+#
+# The limit counts bytes, and a Python string counts characters. The two agree
+# for every pattern CRS writes in a .conf file, which spells non-ASCII as
+# `\x{...}`, but not for the .data files behind `@pmFromFile`: ssrf.data
+# contains `\u2460` and `\u3002`, three bytes each. Measuring in characters
+# there produces a key that passes this check and takes the file down.
+NGINX_MAX_PARAMETER = 4095
 
 # The request component each rule location is matched against.
 LOCATION_VARIABLES = {
@@ -345,15 +364,15 @@ def generate_nginx_waf(rules: List[Dict], crs_ref: str = "latest") -> None:
 
         prefix = "~*" if ignore_case else "~"
         key = f'"{prefix}{_escape_for_config(sanitized_pattern)}"'
-        if len(key) > NGINX_MAX_PARAMETER:
+        if len(key.encode("utf-8")) > NGINX_MAX_PARAMETER:
             # nginx refuses a single configuration parameter longer than 4096
             # characters ("too long parameter"), and one over-long pattern makes
             # the whole file unloadable. Verified against nginx 1.31.5: the
             # quoted token including `~*` may be at most 4096 characters.
             skipped_too_long += 1
             logger.warning(
-                f"Skipping rule {rule_id}: pattern is {len(key)} characters, "
-                f"over nginx's {NGINX_MAX_PARAMETER}-character parameter limit"
+                f"Skipping rule {rule_id}: key is {len(key.encode('utf-8'))} "
+                f"bytes, over nginx's {NGINX_MAX_PARAMETER}-byte parameter limit"
             )
             continue
 

--- a/tests/test_parameter_limit.py
+++ b/tests/test_parameter_limit.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+NGINX_MAX_PARAMETER, checked against nginx rather than against a comment.
+
+One over-long parameter is not one lost rule. nginx refuses the file, so the
+whole generated rule set stops loading, and that failure shipped once already
+(#22). The constant is therefore worth pinning to what nginx actually does,
+which is what this does: it builds a map with a key of exactly the declared
+limit and one a single byte longer, and asserts nginx accepts the first and
+refuses the second.
+
+Two things it protects:
+
+  - the boundary itself. The constant was 4096 and the comparison was `>`, so a
+    key nginx refuses was emitted. The boundary is discovered here rather than
+    written down, so a build that moved it fails this instead of shipping a
+    configuration that will not load.
+  - the unit. nginx counts bytes; a Python string counts characters. Every
+    pattern CRS writes in a .conf file is ASCII, because non-ASCII is spelled
+    `\\x{...}`, so the two agree today. They stop agreeing the moment anything
+    reads the .data files behind `@pmFromFile`: ssrf.data contains `\\u2460`
+    and `\\u3002`, three bytes each.
+
+Usage:
+    python3 tests/test_parameter_limit.py
+
+Requires the `nginx` binary; skips with status 0 if it is not on PATH.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import json2nginx  # noqa: E402
+
+failures = 0
+checks = 0
+
+
+def check(description, actual, expected):
+    global failures, checks
+    checks += 1
+    if actual != expected:
+        failures += 1
+        print(f"  FAIL  {description}")
+        print(f"        expected {expected!r}, got {actual!r}")
+
+
+def loads(key: str) -> bool:
+    """Reports whether nginx accepts a map holding this one key."""
+    with tempfile.TemporaryDirectory() as tmp:
+        workdir = Path(tmp)
+        conf = workdir / "nginx.conf"
+        # Every path nginx opens during `-t` is pointed inside the work
+        # directory. The packaged defaults under /run, /var/log and
+        # /var/lib/nginx are not writable by an unprivileged user, and nginx
+        # refuses the configuration for that reason rather than for the key,
+        # which turns this probe into one that answers no to everything.
+        conf.write_text(
+            f"pid {workdir}/nginx.pid;\n"
+            f"error_log {workdir}/error.log;\n"
+            "events { worker_connections 64; }\n"
+            "http {\n"
+            "  access_log off;\n"
+            f"  client_body_temp_path {workdir}/client_body;\n"
+            f"  proxy_temp_path {workdir}/proxy;\n"
+            f"  fastcgi_temp_path {workdir}/fastcgi;\n"
+            f"  uwsgi_temp_path {workdir}/uwsgi;\n"
+            f"  scgi_temp_path {workdir}/scgi;\n"
+            "  map $args $probe {\n"
+            '    default "";\n'
+            f'    {key} "1";\n'
+            "  }\n"
+            "  server { listen 18997; location / { return 204; } }\n"
+            "}\n"
+        )
+        result = subprocess.run(
+            ["nginx", "-t", "-c", str(conf), "-p", str(workdir)],
+            # nginx quotes the offending key back, truncated at a byte
+            # boundary, so its own error message is not valid UTF-8 when the
+            # key is multibyte. That is itself the point being tested.
+            capture_output=True, encoding="utf-8", errors="replace",
+        )
+        return result.returncode == 0
+
+
+def key_of(size_in_bytes: int, filler: str = "a") -> str:
+    """A quoted, valid map key of exactly this many bytes."""
+    unit = len(filler.encode("utf-8"))
+    body = filler * ((size_in_bytes - 4) // unit)
+    key = '"~*' + body + '"'
+    assert len(key.encode("utf-8")) == size_in_bytes, len(key.encode("utf-8"))
+    return key
+
+
+if shutil.which("nginx") is None:
+    print("nginx is not on PATH: skipping the parameter limit check.")
+    sys.exit(0)
+
+limit = json2nginx.NGINX_MAX_PARAMETER
+
+# Discovered rather than asserted. Measured at 4095 bytes on nginx 1.31.5 and on
+# the nginx the Ubuntu runners install, which is NGX_CONF_BUFFER less the
+# terminating byte, but a build that compiled it differently would move it. What
+# this needs to know is not the number, it is that the constant is at or below
+# whatever the nginx in use accepts.
+low, high = 16, 8192
+while low < high:
+    middle = (low + high + 1) // 2
+    if loads(key_of(middle)):
+        low = middle
+    else:
+        high = middle - 1
+accepted = low
+print(f"\nthis nginx accepts a map key of at most {accepted} bytes")
+
+print("the boundary")
+check(f"NGINX_MAX_PARAMETER ({limit}) is not above it",
+      limit <= accepted, True)
+check("a key one byte over what it accepts is refused",
+      loads(key_of(accepted + 1)), False)
+
+print("the unit")
+# Three bytes per character, so this key is over the limit in bytes and a third
+# of it in characters. Measuring in characters would call it comfortably short,
+# emit it, and take the whole file down.
+oversize = next(n for n in range(accepted + 1, accepted + 8) if (n - 4) % 3 == 0)
+multibyte = key_of(oversize, filler="\u2460")
+check(f"a multibyte key of {oversize} bytes is refused", loads(multibyte), False)
+check("and it is under the limit in characters, which is the trap",
+      len(multibyte) < limit, True)
+
+print(f"\n{checks - failures}/{checks} checks passed")
+if failures:
+    print(f"{failures} failing")
+    sys.exit(1)

--- a/tests/validate_nginx.py
+++ b/tests/validate_nginx.py
@@ -22,6 +22,9 @@ import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import json2nginx  # noqa: E402
 DEFAULT_DIR = REPO_ROOT / "waf_patterns" / "nginx"
 
 
@@ -73,12 +76,12 @@ def main() -> int:
     # An over-long parameter is reported by nginx with a line number but no
     # measurement, so report it here where the number is useful.
     over_limit = [
-        (n, len(line))
+        (n, len(line.encode("utf-8")))
         for n, line in enumerate(maps_file.read_text().splitlines(), 1)
-        if len(line.strip()) > 4096
+        if len(line.strip().encode("utf-8")) > json2nginx.NGINX_MAX_PARAMETER
     ]
     for line_number, length in over_limit:
-        print(f"      {maps_file.name}:{line_number} is {length} characters")
+        print(f"      {maps_file.name}:{line_number} is {length} bytes")
 
     with tempfile.TemporaryDirectory() as tmp:
         workdir = Path(tmp)


### PR DESCRIPTION
Found while prototyping #52, and a prerequisite for it. Neither defect is reachable with the rules emitted today, and both become reachable as soon as anything reads CRS's `.data` files.

One over-long parameter is not one lost rule: nginx refuses the file, so the whole rule set stops loading. That failure shipped once already (#22), which is what makes this worth measuring rather than asserting.

## The value was one above the boundary

The comment claimed a quoted map key of 4096 characters loads. Binary-searched with `nginx -t`, on nginx 1.31.5 and on the nginx the Ubuntu runners install:

| key | result |
|---|---|
| 4094 bytes | loads |
| 4095 bytes | loads |
| 4096 bytes | `too long parameter, probably missing terminating " character` |

The comparison was `len(key) > 4096`, so a key nginx refuses was emitted.

The limit is on the parameter, not the line: a 4095-byte key loads on a line of 4508 characters, so padding the value or the indentation changes nothing.

## The unit was wrong

nginx counts bytes. A Python string counts characters. They agree for every pattern CRS writes in a `.conf` file, because non-ASCII is spelled `\x{...}` there.

They stop agreeing the moment anything reads the `.data` files behind `@pmFromFile`. `ssrf.data` contains `①` through `⑨` and `。`, three bytes each, so a key built from it can be 1365 characters and 4095 bytes.

That is not hypothetical. It is how this was found: a prototype of the `@pm` conversion produced one, and nginx refused the file with an error message that was not valid UTF-8, because it had truncated the key mid-character when quoting it back.

## Test

`tests/test_parameter_limit.py` binary-searches the local nginx for the boundary, prints it, and fails if `NGINX_MAX_PARAMETER` is above it. The number is discovered rather than written down, so a build that moved it fails this test instead of shipping a configuration that will not load, and no arbitrary safety margin is needed.

It then builds a three-byte-per-character key that is over the boundary in bytes and well under it in characters, and asserts nginx refuses it. That is the trap the unit fix closes.

One thing worth knowing if you write a probe like this: it points `pid`, `error_log` and the five temp paths inside its work directory. Without that, nginx refuses every configuration it is handed for lack of write access to the packaged defaults, not because of the key under test, and the search happily reports a limit of 16 bytes. An earlier revision of this branch did exactly that and I read it as "the Ubuntu build has a lower limit", which it does not.

Skips with status 0 when nginx is not on PATH. Added to the CI job.

`tests/validate_nginx.py` now reports over-long lines in bytes, against the constant rather than a literal.

## Output

Unchanged. The longest key emitted is 3840 bytes and the shortest one already being skipped is 4614, so the same sixteen rules are dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)