### PR TITLE
Guard against empty maps file causing misleading nginx error

### DIFF
--- a/tests/validate_nginx.py
+++ b/tests/validate_nginx.py
@@ -83,6 +83,12 @@ def main() -> int:
     for line_number, length in over_limit:
         print(f"      {maps_file.name}:{line_number} is {length} bytes")
 
+    # Guard against empty maps file to avoid misleading nginx diagnostics
+    maps_content = maps_file.read_text()
+    if not any(line.strip() for line in maps_content.splitlines()):
+        print(f"FAIL  {maps_file} is empty")
+        return 1
+
     with tempfile.TemporaryDirectory() as tmp:
         workdir = Path(tmp)
         conf = workdir / "nginx.conf"
@@ -94,11 +100,11 @@ def main() -> int:
 
     if result.returncode == 0:
         entries = sum(
-            1 for line in maps_file.read_text().splitlines()
+            1 for line in maps_content.splitlines()
             if line.strip().startswith('"~')
         )
         maps = sum(
-            1 for line in maps_file.read_text().splitlines()
+            1 for line in maps_content.splitlines()
             if line.startswith("map ")
         )
         print(f"ok    nginx accepts the generated configuration "


### PR DESCRIPTION
### FabGPT — code quality

**File:** `tests/validate_nginx.py`

**Rationale:** The script reads `maps_file.read_text().splitlines()` multiple times without checking if the file is empty. If `waf_maps.conf` exists but is empty, `entries` and `maps` counts become 0, and the success message reports '0 maps, 0 entries' — which is misleading and hides the real issue. More critically, if the file is empty, the `include` directive in the generated nginx.conf points to an empty file, and nginx may report a generic error like 'no configuration found' without clear context. The real defect is that the script does not validate that the maps file contains at least one non-comment, non-empty line before proceeding, risking confusing diagnostics.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `779e56cc5b8ae905` · HITL-approved before opening.

<details>
<summary><b>How this change was checked</b> — 4 gates before a human saw it</summary>

| gate | result |
|---|---|
| deterministic slop gates | passed — no known no-op / false-guard pattern |
| LLM reviewer | `ship` · 82/100 |
| adversarial panel | survived — 2/3 could not refute (correctness, necessity, reproducibility) · dissent: **reproducibility** no evidence any caller produces an empty maps file, and existing tests accept empty files without error, making the clai |
| human review | read and approved before this PR was opened |

The adversarial panel is three independent skeptics — correctness, necessity, reproducibility — each defaulting to *refuted*, voting “cannot refute” only after failing to find a reason to reject. A gate that did not run is not listed.
</details>
<!-- fabgpt:{"task_id":"779e56cc5b8ae905","source":"quality","model":"qwen3-coder-next","severity":"WARN","iterations":1,"inference_s":7.67,"prompt_sha":"dbf8708ae0d2e97b","triage":"WARN","review":{"verdict":"ship","score":82},"escalation":{"verdict":"OK","refuted":1,"model":"gpt-oss-120b"}} -->